### PR TITLE
fix: clippy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         cargo:
           - name: "Clippy"
             cmd: clippy
-            args: --workspace --all-features --tests -- -D clippy::all -W clippy::style
+            args: --workspace --all-features --tests -- -D warnings
             rust: stable
           - name: "Formatting"
             cmd: fmt

--- a/relay_rpc/src/auth/cacao.rs
+++ b/relay_rpc/src/auth/cacao.rs
@@ -96,7 +96,7 @@ impl Cacao {
         );
 
         if let Some(statement) = &self.p.statement {
-            write!(message, "{}\n", statement)?;
+            writeln!(message, "{}", statement)?;
         }
 
         write!(


### PR DESCRIPTION
# Description

Fixes this clippy warning and prevents warnings from entering the codebase in the future:

![image](https://github.com/WalletConnect/WalletConnectRust/assets/1979423/5a5219a7-eb3d-49ed-9b60-b91907007566)

`-D warnings` is better than `-D clippy::all` because it also denies regular compiler warnings, not just clippy warnings. `clippy:all` is a warning by default.

Not sure why `-W clippy::style` was there; all warnings should be denied.

## How Has This Been Tested?

Not tested.

`writeln` change manually reviewed, should behave exactly the same.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
