### PR TITLE
fix: session methods analytics

### DIFF
--- a/relay_client/src/http.rs
+++ b/relay_client/src/http.rs
@@ -114,6 +114,7 @@ impl Client {
             pairing_topic,
             session_proposal: session_proposal.into(),
             attestation: attestation.into(),
+            analytics: None,
         })
         .await
     }
@@ -122,14 +123,15 @@ impl Client {
         &self,
         pairing_topic: Topic,
         session_topic: Topic,
-        pairing_response: impl Into<Arc<str>>,
+        session_proposal_response: impl Into<Arc<str>>,
         session_settlement_request: impl Into<Arc<str>>,
     ) -> Response<rpc::ApproveSession> {
         self.request(rpc::ApproveSession {
             pairing_topic,
             session_topic,
-            pairing_response: pairing_response.into(),
+            session_proposal_response: session_proposal_response.into(),
             session_settlement_request: session_settlement_request.into(),
+            analytics: None,
         })
         .await
     }

--- a/relay_client/src/websocket.rs
+++ b/relay_client/src/websocket.rs
@@ -173,6 +173,7 @@ impl Client {
             pairing_topic,
             session_proposal: session_proposal.into(),
             attestation: attestation.into(),
+            analytics: None,
         });
 
         self.request(request);
@@ -184,14 +185,15 @@ impl Client {
         &self,
         pairing_topic: Topic,
         session_topic: Topic,
-        pairing_response: impl Into<Arc<str>>,
+        session_proposal_response: impl Into<Arc<str>>,
         session_settlement_request: impl Into<Arc<str>>,
     ) -> ResponseFuture<ApproveSession> {
         let (request, response) = create_request(ApproveSession {
             pairing_topic,
             session_topic,
-            pairing_response: pairing_response.into(),
+            session_proposal_response: session_proposal_response.into(),
             session_settlement_request: session_settlement_request.into(),
+            analytics: None,
         });
 
         self.request(request);

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -63,6 +63,10 @@ fn propose_session() {
                 .into(),
             session_proposal: "proposal".into(),
             attestation: Some("attestation".into()),
+            analytics: Some(AnalyticsData {
+                correlation_id: Some(42),
+                ..Default::default()
+            }),
         }),
     ));
 
@@ -70,7 +74,7 @@ fn propose_session() {
 
     assert_eq!(
         &serialized,
-        r#"{"id":1,"jsonrpc":"2.0","method":"wc_proposeSession","params":{"pairingTopic":"c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840","sessionProposal":"proposal","attestation":"attestation"}}"#
+        r#"{"id":1,"jsonrpc":"2.0","method":"wc_proposeSession","params":{"pairingTopic":"c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840","sessionProposal":"proposal","attestation":"attestation","correlationId":42}}"#
     );
 
     let deserialized: Payload = serde_json::from_str(&serialized).unwrap();
@@ -87,8 +91,12 @@ fn approve_session() {
                 .into(),
             session_topic: "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9841"
                 .into(),
-            pairing_response: "pairing_response".into(),
+            session_proposal_response: "pairing_response".into(),
             session_settlement_request: "session_settlement_request".into(),
+            analytics: Some(AnalyticsData {
+                correlation_id: Some(42),
+                ..Default::default()
+            }),
         }),
     ));
 
@@ -96,7 +104,7 @@ fn approve_session() {
 
     assert_eq!(
         &serialized,
-        r#"{"id":1,"jsonrpc":"2.0","method":"wc_approveSession","params":{"pairingTopic":"c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840","sessionTopic":"c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9841","pairingResponse":"pairing_response","sessionSettlementRequest":"session_settlement_request"}}"#
+        r#"{"id":1,"jsonrpc":"2.0","method":"wc_approveSession","params":{"pairingTopic":"c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840","sessionTopic":"c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9841","sessionProposalResponse":"pairing_response","sessionSettlementRequest":"session_settlement_request","correlationId":42}}"#
     );
 
     let deserialized: Payload = serde_json::from_str(&serialized).unwrap();


### PR DESCRIPTION
# Description

This adds the analytics data to the `wc_proposeSession` and `wc_approveSession` methods.

## How Has This Been Tested?

Existing tests here and in the relay.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
