### PR TITLE
fix: add missing derives to rpc payloads

### DIFF
--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -11,11 +11,10 @@ cacao-tests = []
 [dependencies]
 bs58 = "0.4"
 data-encoding = "2.3"
-derive_more = { version = "0.99", default-features = false, features = [
+derive_more = { version = "2.0", default-features = false, features = [
     "display",
     "from",
     "as_ref",
-    "as_mut",
 ] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-aux = { version = "4.1", default-features = false }
@@ -41,6 +40,7 @@ alloy = { version = "0.3", optional = true, features = [
     "rpc-types-eth",
 ] }
 strum = { version = "0.26", features = ["strum_macros", "derive"] }
+enum-as-inner = "0.6"
 
 [dev-dependencies]
 tokio = { version = "1.47", features = ["test-util", "macros"] }

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -6,6 +6,8 @@ use {
         domain::{DidKey, MessageId, SubscriptionId, Topic},
         serde_helpers::json_value,
     },
+    derive_more::{Deref, DerefMut},
+    enum_as_inner::EnumAsInner,
     serde::{de::DeserializeOwned, Deserialize, Serialize},
     std::{fmt::Debug, sync::Arc},
 };
@@ -65,7 +67,7 @@ pub trait ServiceRequest: Serializable {
 }
 
 /// Enum representing a JSON RPC payload.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, EnumAsInner)]
 #[serde(untagged)]
 pub enum Payload {
     /// An inbound request.
@@ -1024,7 +1026,7 @@ pub struct SubscriptionData {
 }
 
 /// Enum representing parameters of all possible RPC requests.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, EnumAsInner)]
 #[serde(tag = "method", content = "params")]
 pub enum Params {
     /// Parameters to create topic.
@@ -1102,7 +1104,7 @@ pub enum Params {
 }
 
 /// Data structure representing a JSON RPC request.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Deref, DerefMut)]
 pub struct Request {
     /// ID this message corresponds to.
     pub id: MessageId,
@@ -1112,6 +1114,8 @@ pub struct Request {
 
     /// The parameters required to fulfill this request.
     #[serde(flatten)]
+    #[deref]
+    #[deref_mut]
     pub params: Params,
 }
 


### PR DESCRIPTION
# Description

This adds some convenience impls to RPC payloads for easier access to nested data.

## How Has This Been Tested?

Relay integration.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
