### PR TITLE
fix: missing derive features

### DIFF
--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -12,6 +12,8 @@ cacao-tests = []
 bs58 = "0.4"
 data-encoding = "2.3"
 derive_more = { version = "2.0", default-features = false, features = [
+    "deref",
+    "deref_mut",
     "display",
     "from",
     "as_ref",


### PR DESCRIPTION
# Description

This adds some missing `derive_more` features.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
