### PR TITLE
fix: add a generic 'access denied' RPC error

### DIFF
--- a/relay_rpc/src/rpc/error.rs
+++ b/relay_rpc/src/rpc/error.rs
@@ -48,6 +48,9 @@ pub enum AuthError {
 
     #[error("Country blocked")]
     CountryBlocked,
+
+    #[error("Access denied")]
+    AccessDenied,
 }
 
 /// Request payload validation problems.


### PR DESCRIPTION
# Description

This adds a generic 'access denied' error for the RPC response. Needed for the IP blacklisting feature.

## How Has This Been Tested?

Not tested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
