### PR TITLE
feat: new Topic ID format

### DIFF
--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -43,6 +43,7 @@ alloy = { version = "0.3", optional = true, features = [
 ] }
 strum = { version = "0.26", features = ["strum_macros", "derive"] }
 enum-as-inner = "0.6"
+arrayvec = { version = "0.7", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.47", features = ["test-util", "macros"] }

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -43,11 +43,14 @@ alloy = { version = "0.3", optional = true, features = [
 ] }
 strum = { version = "0.26", features = ["strum_macros", "derive"] }
 enum-as-inner = "0.6"
-arrayvec = { version = "0.7", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.47", features = ["test-util", "macros"] }
 alloy = { version = "0.3", features = ["node-bindings"] }
+postcard = { version = "1.0", default-features = false, features = [
+    "alloc",
+    "use-std",
+] }
 
 [build-dependencies]
 serde_json = "1.0"

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -36,7 +36,7 @@ pub enum ClientIdDecodingError {
 
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("Failed to decode Topic: {0}")]
-pub struct TopicDecodingError(TopicDecodingErrorInner);
+pub struct TopicDecodingError(#[source] TopicDecodingErrorInner);
 
 #[derive(Debug, Clone, thiserror::Error)]
 enum TopicDecodingErrorInner {

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -10,7 +10,7 @@ use {
     },
     derive_more::{AsMut, AsRef, From},
     ed25519_dalek::VerifyingKey,
-    rand::RngCore,
+    rand::RngCore as _,
     serde::{Deserialize, Serialize},
     serde_aux::prelude::deserialize_number_from_string,
     std::{str::FromStr, sync::Arc},
@@ -43,7 +43,7 @@ enum TopicDecodingErrorInner {
     #[error("Invalid hex: {0}")]
     InvalidHex(#[from] DecodingError),
 
-    #[error("Unknown kind: {0}")]
+    #[error("Unknown version: {0}")]
     UnknownVersion(u8),
 
     #[error("Unknown region: {0}")]

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -8,6 +8,7 @@ use {
         },
         new_type,
     },
+    arrayvec::ArrayVec,
     derive_more::{AsMut, AsRef, From},
     ed25519_dalek::VerifyingKey,
     rand::RngCore,
@@ -362,17 +363,17 @@ where
     Ok(data)
 }
 
-#[derive(Clone, Debug, From)]
+#[derive(Clone, Debug, From, Eq, PartialEq, Hash)]
 #[from(forward)]
 pub struct DecodedTopic(DecodedTopicInner);
 
-#[derive(Clone, Debug, From)]
+#[derive(Clone, Debug, From, Eq, PartialEq, Hash)]
 enum DecodedTopicInner {
     New(TopicId),
     Legacy(LegacyTopicId),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct LegacyTopicId([u8; 32]);
 
 impl LegacyTopicId {
@@ -381,7 +382,7 @@ impl LegacyTopicId {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TopicId([u8; 18]);
 
 impl TopicId {
@@ -389,9 +390,11 @@ impl TopicId {
     const VERSION_BYTE_IDX: usize = 0;
 
     fn decode(s: &str) -> Result<Self, TopicDecodingErrorInner> {
-        use TopicDecodingErrorInner as Error;
+        Self::from_bytes(hex_decode_array(s)?)
+    }
 
-        let bytes: [u8; 18] = hex_decode_array(s)?;
+    fn from_bytes(bytes: [u8; 18]) -> Result<Self, TopicDecodingErrorInner> {
+        use TopicDecodingErrorInner as Error;
 
         // Validate the `TopicVersion` byte
         let version_byte = bytes[Self::VERSION_BYTE_IDX];
@@ -576,6 +579,12 @@ impl std::fmt::Display for DecodedTopic {
     }
 }
 
+impl AsRef<[u8]> for DecodedTopic {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes()
+    }
+}
+
 impl From<DecodedTopic> for Topic {
     fn from(val: DecodedTopic) -> Self {
         Self(val.to_string().into())
@@ -587,6 +596,43 @@ impl TryFrom<Topic> for DecodedTopic {
 
     fn try_from(value: Topic) -> Result<Self, Self::Error> {
         value.as_ref().parse()
+    }
+}
+
+impl Serialize for DecodedTopic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.bytes().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DecodedTopic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes = ArrayVec::<u8, 32>::deserialize(deserializer)?;
+
+        let invalid_length_error = || serde::de::Error::custom("invalid length");
+
+        match bytes.len() {
+            18 => {
+                let mut buf: [u8; 18] = Default::default();
+                buf.copy_from_slice(&bytes);
+                TopicId::from_bytes(buf)
+                    .map(Into::into)
+                    .map_err(serde::de::Error::custom)
+            }
+            32 => bytes
+                .into_inner()
+                .map(LegacyTopicId)
+                .map(Into::into)
+                .map_err(|_| invalid_length_error()),
+
+            _ => Err(invalid_length_error()),
+        }
     }
 }
 

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -8,7 +8,7 @@ use {
         },
         new_type,
     },
-    derive_more::{AsMut, AsRef},
+    derive_more::{AsMut, AsRef, From},
     ed25519_dalek::VerifyingKey,
     serde::{Deserialize, Serialize},
     serde_aux::prelude::deserialize_number_from_string,
@@ -31,6 +31,22 @@ pub enum ClientIdDecodingError {
 
     #[error("Invalid issuer pubkey length")]
     Length,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("Failed to decode Topic: {0}")]
+pub struct TopicDecodingError(TopicDecodingErrorInner);
+
+#[derive(Debug, Clone, thiserror::Error)]
+enum TopicDecodingErrorInner {
+    #[error("Invalid hex: {0}")]
+    InvalidHex(#[from] DecodingError),
+
+    #[error("Unknown kind: {0}")]
+    UnknownKind(u8),
+
+    #[error("Unknown region: {0}")]
+    UnknownRegion(u8),
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -202,6 +218,16 @@ new_type!(
     Topic: Arc<str>
 );
 
+impl Topic {
+    pub fn decode(&self) -> Result<DecodedTopic, TopicDecodingError> {
+        self.0.parse()
+    }
+
+    pub fn generate() -> Self {
+        Self::from(DecodedTopic::generate())
+    }
+}
+
 new_type!(
     #[doc = "Represents the subscription ID type."]
     #[as_ref(forward)]
@@ -267,32 +293,13 @@ macro_rules! impl_byte_array_newtype {
             type Err = DecodingError;
 
             fn from_str(val: &str) -> Result<Self, Self::Err> {
-                let enc_len = val.len();
-                if enc_len == 0 {
-                    return Err(DecodingError::Length);
-                }
-
-                let dec_len = data_encoding::HEXLOWER_PERMISSIVE
-                    .decode_len(enc_len)
-                    .map_err(|_| DecodingError::Length)?;
-
-                if dec_len != $ByteLength {
-                    return Err(DecodingError::Length);
-                }
-
-                let mut data = Self::default();
-
-                data_encoding::HEXLOWER_PERMISSIVE
-                    .decode_mut(val.as_bytes(), &mut data.0)
-                    .map_err(|_| DecodingError::Encoding)?;
-
-                Ok(data)
+                hex_decode_array(val).map(Self)
             }
         }
 
         impl std::fmt::Display for $NewType {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_str(&data_encoding::HEXLOWER_PERMISSIVE.encode(&self.0))
+                f.write_str(&hex_encode(&self.0))
             }
         }
 
@@ -324,7 +331,192 @@ macro_rules! impl_byte_array_newtype {
     };
 }
 
-impl_byte_array_newtype!(DecodedTopic, Topic, 32);
+fn hex_encode(bytes: &[u8]) -> String {
+    data_encoding::HEXLOWER_PERMISSIVE.encode(bytes)
+}
+
+fn hex_decode_array<const N: usize>(val: &str) -> Result<[u8; N], DecodingError>
+where
+    [u8; N]: Default,
+{
+    let enc_len = val.len();
+    if enc_len == 0 {
+        return Err(DecodingError::Length);
+    }
+
+    let dec_len = data_encoding::HEXLOWER_PERMISSIVE
+        .decode_len(enc_len)
+        .map_err(|_| DecodingError::Length)?;
+
+    if dec_len != N {
+        return Err(DecodingError::Length);
+    }
+
+    let mut data = <[u8; N]>::default();
+
+    data_encoding::HEXLOWER_PERMISSIVE
+        .decode_mut(val.as_bytes(), &mut data)
+        .map_err(|_| DecodingError::Encoding)?;
+
+    Ok(data)
+}
+
+#[derive(Clone, Debug, From)]
+#[from(forward)]
+pub struct DecodedTopic(DecodedTopicInner);
+
+#[derive(Clone, Debug, From)]
+enum DecodedTopicInner {
+    Legacy(LegacyTopicId),
+    Pairing(PairingTopicId),
+}
+
+#[derive(Clone, Debug)]
+struct LegacyTopicId([u8; 32]);
+
+impl LegacyTopicId {
+    fn decode(s: &str) -> Result<Self, TopicDecodingErrorInner> {
+        hex_decode_array(s).map(Self).map_err(Into::into)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PairingTopicId([u8; 18]);
+
+impl PairingTopicId {
+    const REGION_BYTE_IDX: usize = 1;
+
+    fn decode(s: &str) -> Result<Self, TopicDecodingErrorInner> {
+        use TopicDecodingErrorInner as Error;
+
+        let bytes: [u8; 18] = hex_decode_array(s)?;
+
+        // Validate the `Region` byte
+        let region_byte = bytes[Self::REGION_BYTE_IDX];
+        let _ = Region::try_from_u8(region_byte).ok_or(Error::UnknownRegion(region_byte))?;
+
+        Ok(Self(bytes))
+    }
+
+    fn region(&self) -> Region {
+        // NOTE: `unwrap` is fine here, as we've validated the `Region` byte in the
+        // constructor
+        Region::try_from_u8(self.0[Self::REGION_BYTE_IDX]).unwrap()
+    }
+}
+
+#[repr(u8)]
+enum TopicKind {
+    Pairing = 0,
+}
+
+impl TryFrom<u8> for TopicKind {
+    type Error = TopicDecodingErrorInner;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Self::Pairing,
+            kind => return Err(TopicDecodingErrorInner::UnknownKind(kind)),
+        })
+    }
+}
+
+/// Region of a Relay deployment.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Region {
+    Eu = 0,
+    Us = 1,
+    Ap = 2,
+    Sa = 3,
+}
+
+impl Region {
+    fn try_from_u8(val: u8) -> Option<Self> {
+        Some(match val {
+            0 => Self::Eu,
+            1 => Self::Us,
+            2 => Self::Ap,
+            3 => Self::Sa,
+            _ => return None,
+        })
+    }
+}
+
+impl FromStr for DecodedTopic {
+    type Err = TopicDecodingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::decode(s).map_err(TopicDecodingError)
+    }
+}
+
+impl DecodedTopic {
+    pub fn generate() -> Self {
+        let bytes: [u8; 32] = rand::Rng::gen(&mut rand::thread_rng());
+
+        Self(LegacyTopicId(bytes).into())
+    }
+
+    fn decode(s: &str) -> Result<Self, TopicDecodingErrorInner> {
+        // Legacy topic ID
+        if s.len() == 64 {
+            return LegacyTopicId::decode(s).map(Into::into);
+        }
+
+        if s.len() < 2 {
+            return Err(DecodingError::Length.into());
+        }
+
+        let kind = u8::from_str_radix(&s[..2], 16).map_err(|_| DecodingError::Encoding)?;
+
+        match TopicKind::try_from(kind)? {
+            TopicKind::Pairing => PairingTopicId::decode(s).map(Into::into),
+        }
+    }
+
+    /// Returns the [`Region`] the [`Topic`] is being handled by.
+    pub fn region(&self) -> Option<Region> {
+        match &self.0 {
+            DecodedTopicInner::Legacy(_) => None,
+            DecodedTopicInner::Pairing(topic_id) => Some(topic_id.region()),
+        }
+    }
+
+    /// Returns the underlying bytes of this [`DecodedTopic`].
+    pub fn bytes(&self) -> &[u8] {
+        match &self.0 {
+            DecodedTopicInner::Legacy(topic_id) => &topic_id.0,
+            DecodedTopicInner::Pairing(topic_id) => &topic_id.0,
+        }
+    }
+
+    /// Converts this [`DecodedTopic`] to a [`Vec`] of the underlying bytes.
+    pub fn to_bytes(self) -> Vec<u8> {
+        self.bytes().to_vec()
+    }
+}
+
+impl std::fmt::Display for DecodedTopic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&hex_encode(self.bytes()))
+    }
+}
+
+impl From<DecodedTopic> for Topic {
+    fn from(val: DecodedTopic) -> Self {
+        Self(val.to_string().into())
+    }
+}
+
+impl TryFrom<Topic> for DecodedTopic {
+    type Error = TopicDecodingError;
+
+    fn try_from(value: Topic) -> Result<Self, Self::Error> {
+        value.as_ref().parse()
+    }
+}
+
 impl_byte_array_newtype!(DecodedSubscription, SubscriptionId, 32);
 impl_byte_array_newtype!(DecodedAuthSubject, AuthSubject, 32);
 impl_byte_array_newtype!(DecodedProjectId, ProjectId, 16);
@@ -353,9 +545,25 @@ mod test {
 
         assert_eq!(topic_str, Topic::from(topic_bin).as_ref());
 
-        assert!(matches!(
-            "85089843ce".parse::<DecodedTopic>(),
-            Err(DecodingError::Length)
-        ));
+        assert!("85089843ce".parse::<DecodedTopic>().is_err());
+    }
+
+    #[test]
+    fn pairing_topic() {
+        let topic = DecodedTopic::decode("000032c2d0a76742f2d6852b5f531a460abc").unwrap();
+        assert_eq!(topic.region(), Some(Region::Eu));
+
+        let topic = DecodedTopic::decode("000132c2d0a76742f2d6852b5f531a460abc").unwrap();
+        assert_eq!(topic.region(), Some(Region::Us));
+
+        let topic = DecodedTopic::decode("000232c2d0a76742f2d6852b5f531a460abc").unwrap();
+        assert_eq!(topic.region(), Some(Region::Ap));
+
+        let topic = DecodedTopic::decode("000332c2d0a76742f2d6852b5f531a460abc").unwrap();
+        assert_eq!(topic.region(), Some(Region::Sa));
+
+        assert!(DecodedTopic::decode("000432c2d0a76742f2d6852b5f531a460abc").is_err());
+        assert!(DecodedTopic::decode("010032c2d0a76742f2d6852b5f531a460abc").is_err());
+        assert!(DecodedTopic::decode("000032c2d0a76742f2d6852b5f531a460abcd").is_err());
     }
 }

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -719,12 +719,14 @@ mod test {
 
     // These are the old definitions of `Topic` and `DecodedTopic`.
     // We need them to make sure that serialization is backwards compatible.
+    #[allow(dead_code)]
     new_type!(
         #[doc = "Represents the topic type."]
         #[as_ref(forward)]
         #[from(forward)]
         OldTopic: Arc<str>
     );
+    #[allow(dead_code)]
     impl_byte_array_newtype!(OldDecodedTopic, OldTopic, 32);
 
     #[test]

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -10,6 +10,7 @@ use {
     },
     derive_more::{AsMut, AsRef, From},
     ed25519_dalek::VerifyingKey,
+    rand::RngCore,
     serde::{Deserialize, Serialize},
     serde_aux::prelude::deserialize_number_from_string,
     std::{str::FromStr, sync::Arc},
@@ -43,7 +44,7 @@ enum TopicDecodingErrorInner {
     InvalidHex(#[from] DecodingError),
 
     #[error("Unknown kind: {0}")]
-    UnknownKind(u8),
+    UnknownVersion(u8),
 
     #[error("Unknown region: {0}")]
     UnknownRegion(u8),
@@ -367,8 +368,8 @@ pub struct DecodedTopic(DecodedTopicInner);
 
 #[derive(Clone, Debug, From)]
 enum DecodedTopicInner {
+    New(TopicId),
     Legacy(LegacyTopicId),
-    Pairing(PairingTopicId),
 }
 
 #[derive(Clone, Debug)]
@@ -381,21 +382,44 @@ impl LegacyTopicId {
 }
 
 #[derive(Clone, Debug)]
-struct PairingTopicId([u8; 18]);
+struct TopicId([u8; 18]);
 
-impl PairingTopicId {
+impl TopicId {
     const REGION_BYTE_IDX: usize = 1;
+    const VERSION_BYTE_IDX: usize = 0;
 
     fn decode(s: &str) -> Result<Self, TopicDecodingErrorInner> {
         use TopicDecodingErrorInner as Error;
 
         let bytes: [u8; 18] = hex_decode_array(s)?;
 
+        // Validate the `TopicVersion` byte
+        let version_byte = bytes[Self::VERSION_BYTE_IDX];
+        let _ =
+            TopicVersion::try_from_u8(version_byte).ok_or(Error::UnknownVersion(version_byte))?;
+
         // Validate the `Region` byte
         let region_byte = bytes[Self::REGION_BYTE_IDX];
         let _ = Region::try_from_u8(region_byte).ok_or(Error::UnknownRegion(region_byte))?;
 
         Ok(Self(bytes))
+    }
+
+    fn new(version: TopicVersion, region: Region) -> Self {
+        let mut bytes: [u8; 18] = Default::default();
+
+        bytes[Self::VERSION_BYTE_IDX] = version as u8;
+        bytes[Self::REGION_BYTE_IDX] = region as u8;
+
+        rand::thread_rng().fill_bytes(&mut bytes[2..]);
+
+        Self(bytes)
+    }
+
+    fn version(&self) -> TopicVersion {
+        // NOTE: `unwrap` is fine here, as we've validated the `TopicVersion` byte in
+        // the constructor
+        TopicVersion::try_from_u8(self.0[Self::VERSION_BYTE_IDX]).unwrap()
     }
 
     fn region(&self) -> Region {
@@ -405,19 +429,41 @@ impl PairingTopicId {
     }
 }
 
-#[repr(u8)]
-enum TopicKind {
-    Pairing = 0,
+/// [`Topic`] kind.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TopicKind {
+    /// Legacy topic. Can be either a pairing or a session topic.
+    Legacy,
+
+    /// Regular pairing topic.
+    Pairing,
+
+    /// WCP-specific pairing topic.
+    WcpPairing,
 }
 
-impl TryFrom<u8> for TopicKind {
-    type Error = TopicDecodingErrorInner;
+#[repr(u8)]
+enum TopicVersion {
+    PairingV1 = 0,
+    WcpPairingV1 = 1,
+}
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(match value {
-            0 => Self::Pairing,
-            kind => return Err(TopicDecodingErrorInner::UnknownKind(kind)),
+impl TopicVersion {
+    fn try_from_u8(val: u8) -> Option<Self> {
+        Some(match val {
+            0 => Self::PairingV1,
+            1 => Self::WcpPairingV1,
+            _ => return None,
         })
+    }
+}
+
+impl From<TopicVersion> for TopicKind {
+    fn from(kind: TopicVersion) -> Self {
+        match kind {
+            TopicVersion::PairingV1 => Self::Pairing,
+            TopicVersion::WcpPairingV1 => Self::WcpPairing,
+        }
     }
 }
 
@@ -452,10 +498,21 @@ impl FromStr for DecodedTopic {
 }
 
 impl DecodedTopic {
+    /// Generates a new [Legacy](`TopicKind::Legacy`) [`Topic`].
     pub fn generate() -> Self {
         let bytes: [u8; 32] = rand::Rng::gen(&mut rand::thread_rng());
 
         Self(LegacyTopicId(bytes).into())
+    }
+
+    /// Generates a new [Pairing](`TopicKind::Pairing`) [`Topic`].
+    pub fn pairing(region: Region) -> Self {
+        TopicId::new(TopicVersion::PairingV1, region).into()
+    }
+
+    /// Generates a new [WCP Pairing](`TopicKind::WcpPairing`) [`Topic`].
+    pub fn wcp_pairing(region: Region) -> Self {
+        TopicId::new(TopicVersion::WcpPairingV1, region).into()
     }
 
     fn decode(s: &str) -> Result<Self, TopicDecodingErrorInner> {
@@ -468,18 +525,34 @@ impl DecodedTopic {
             return Err(DecodingError::Length.into());
         }
 
-        let kind = u8::from_str_radix(&s[..2], 16).map_err(|_| DecodingError::Encoding)?;
+        TopicId::decode(s).map(Into::into)
+    }
 
-        match TopicKind::try_from(kind)? {
-            TopicKind::Pairing => PairingTopicId::decode(s).map(Into::into),
+    /// Returns [`TopicKind`] of this [`DecodedTopic`].
+    pub fn kind(&self) -> TopicKind {
+        match &self.0 {
+            DecodedTopicInner::New(topic_id) => topic_id.version().into(),
+            DecodedTopicInner::Legacy(_) => TopicKind::Legacy,
+        }
+    }
+
+    /// Indicates whether this topic is being used for WalletConnect Pay.
+    ///
+    /// Note: this can give false negatives for [`TopicKind::Legacy`].
+    pub fn is_wcp(&self) -> bool {
+        match self.kind() {
+            TopicKind::Legacy | TopicKind::Pairing => false,
+            TopicKind::WcpPairing => true,
         }
     }
 
     /// Returns the [`Region`] the [`Topic`] is being handled by.
+    ///
+    /// `None` for [`TopicKind::Legacy`].
     pub fn region(&self) -> Option<Region> {
         match &self.0 {
+            DecodedTopicInner::New(topic_id) => Some(topic_id.region()),
             DecodedTopicInner::Legacy(_) => None,
-            DecodedTopicInner::Pairing(topic_id) => Some(topic_id.region()),
         }
     }
 
@@ -487,11 +560,11 @@ impl DecodedTopic {
     pub fn bytes(&self) -> &[u8] {
         match &self.0 {
             DecodedTopicInner::Legacy(topic_id) => &topic_id.0,
-            DecodedTopicInner::Pairing(topic_id) => &topic_id.0,
+            DecodedTopicInner::New(topic_id) => &topic_id.0,
         }
     }
 
-    /// Converts this [`DecodedTopic`] to a [`Vec`] of the underlying bytes.
+    /// Converts this [`DecodedTopic`] into a [`Vec`] of the underlying bytes.
     pub fn to_bytes(self) -> Vec<u8> {
         self.bytes().to_vec()
     }
@@ -549,21 +622,42 @@ mod test {
     }
 
     #[test]
-    fn pairing_topic() {
+    fn new_topic_format_decoding() {
         let topic = DecodedTopic::decode("000032c2d0a76742f2d6852b5f531a460abc").unwrap();
         assert_eq!(topic.region(), Some(Region::Eu));
+        assert_eq!(topic.kind(), TopicKind::Pairing);
+        assert!(!topic.is_wcp());
 
-        let topic = DecodedTopic::decode("000132c2d0a76742f2d6852b5f531a460abc").unwrap();
+        let topic = DecodedTopic::decode("010132c2d0a76742f2d6852b5f531a460abc").unwrap();
         assert_eq!(topic.region(), Some(Region::Us));
+        assert_eq!(topic.kind(), TopicKind::WcpPairing);
+        assert!(topic.is_wcp());
 
         let topic = DecodedTopic::decode("000232c2d0a76742f2d6852b5f531a460abc").unwrap();
         assert_eq!(topic.region(), Some(Region::Ap));
+        assert_eq!(topic.kind(), TopicKind::Pairing);
+        assert!(!topic.is_wcp());
 
-        let topic = DecodedTopic::decode("000332c2d0a76742f2d6852b5f531a460abc").unwrap();
+        let topic = DecodedTopic::decode("010332c2d0a76742f2d6852b5f531a460abc").unwrap();
         assert_eq!(topic.region(), Some(Region::Sa));
+        assert_eq!(topic.kind(), TopicKind::WcpPairing);
+        assert!(topic.is_wcp());
 
         assert!(DecodedTopic::decode("000432c2d0a76742f2d6852b5f531a460abc").is_err());
-        assert!(DecodedTopic::decode("010032c2d0a76742f2d6852b5f531a460abc").is_err());
+        assert!(DecodedTopic::decode("020032c2d0a76742f2d6852b5f531a460abc").is_err());
         assert!(DecodedTopic::decode("000032c2d0a76742f2d6852b5f531a460abcd").is_err());
+    }
+
+    #[test]
+    fn new_topic_format_constructors() {
+        let topic = DecodedTopic::pairing(Region::Eu);
+        assert_eq!(topic.region(), Some(Region::Eu));
+        assert_eq!(topic.kind(), TopicKind::Pairing);
+        assert!(!topic.is_wcp());
+
+        let topic = DecodedTopic::wcp_pairing(Region::Us);
+        assert_eq!(topic.region(), Some(Region::Us));
+        assert_eq!(topic.kind(), TopicKind::WcpPairing);
+        assert!(topic.is_wcp());
     }
 }

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -720,21 +720,25 @@ mod test {
     // These are the old definitions of `Topic` and `DecodedTopic`.
     // We need them to make sure that serialization is backwards compatible.
     #[allow(dead_code)]
-    new_type!(
-        #[doc = "Represents the topic type."]
-        #[as_ref(forward)]
-        #[from(forward)]
-        OldTopic: Arc<str>
-    );
-    #[allow(dead_code)]
-    impl_byte_array_newtype!(OldDecodedTopic, OldTopic, 32);
+    mod old {
+        use super::*;
+
+        new_type!(
+            #[doc = "Represents the topic type."]
+            #[as_ref(forward)]
+            #[from(forward)]
+            Topic: Arc<str>
+        );
+
+        impl_byte_array_newtype!(DecodedTopic, Topic, 32);
+    }
 
     #[test]
     fn new_topic_format_serialization() {
         // Check that topics previously serialized using the old code can still be
         // deserialized. The only place where this matters is Relay mailbox
         // entry, which uses `postcard`.
-        let topic = OldDecodedTopic::generate();
+        let topic = old::DecodedTopic::generate();
         let serialized_topic_bytes = postcard::to_stdvec(&topic).unwrap();
         let deserialized_topic: DecodedTopic =
             postcard::from_bytes(&serialized_topic_bytes).unwrap();

--- a/relay_rpc/src/domain.rs
+++ b/relay_rpc/src/domain.rs
@@ -8,7 +8,6 @@ use {
         },
         new_type,
     },
-    arrayvec::ArrayVec,
     derive_more::{AsMut, AsRef, From},
     ed25519_dalek::VerifyingKey,
     rand::RngCore,
@@ -604,7 +603,19 @@ impl Serialize for DecodedTopic {
     where
         S: serde::Serializer,
     {
-        self.bytes().serialize(serializer)
+        let bytes = match &self.0 {
+            // We can't change the length of the serialized array, because that would break
+            // non-self-describing serialization formats (`postcard`).
+            // So we leave first 14 bytes as `0`.
+            DecodedTopicInner::New(topic_id) => {
+                let mut buf = [0u8; 32];
+                buf[14..].copy_from_slice(&topic_id.0);
+                buf
+            }
+            DecodedTopicInner::Legacy(topic_id) => topic_id.0,
+        };
+
+        bytes.serialize(serializer)
     }
 }
 
@@ -613,26 +624,25 @@ impl<'de> Deserialize<'de> for DecodedTopic {
     where
         D: serde::Deserializer<'de>,
     {
-        let bytes = ArrayVec::<u8, 32>::deserialize(deserializer)?;
+        let bytes = <[u8; 32]>::deserialize(deserializer)?;
 
-        let invalid_length_error = || serde::de::Error::custom("invalid length");
+        let first_non_zero_byte_idx = bytes
+            .iter()
+            .position(|byte| *byte != 0)
+            .unwrap_or(usize::MAX);
 
-        match bytes.len() {
-            18 => {
-                let mut buf: [u8; 18] = Default::default();
-                buf.copy_from_slice(&bytes);
-                TopicId::from_bytes(buf)
-                    .map(Into::into)
-                    .map_err(serde::de::Error::custom)
+        if first_non_zero_byte_idx >= 14 {
+            let mut buf = [0u8; 18];
+            buf.copy_from_slice(&bytes[14..]);
+
+            // If first 14 bytes are `0`, but the following 18 bytes are invalid `TopicId`,
+            // we consider it to be `LegacyTopicId`.
+            if let Ok(topic_id) = TopicId::from_bytes(buf) {
+                return Ok(topic_id.into());
             }
-            32 => bytes
-                .into_inner()
-                .map(LegacyTopicId)
-                .map(Into::into)
-                .map_err(|_| invalid_length_error()),
-
-            _ => Err(invalid_length_error()),
         }
+
+        Ok(LegacyTopicId(bytes).into())
     }
 }
 
@@ -705,5 +715,83 @@ mod test {
         assert_eq!(topic.region(), Some(Region::Us));
         assert_eq!(topic.kind(), TopicKind::WcpPairing);
         assert!(topic.is_wcp());
+    }
+
+    // These are the old definitions of `Topic` and `DecodedTopic`.
+    // We need them to make sure that serialization is backwards compatible.
+    new_type!(
+        #[doc = "Represents the topic type."]
+        #[as_ref(forward)]
+        #[from(forward)]
+        OldTopic: Arc<str>
+    );
+    impl_byte_array_newtype!(OldDecodedTopic, OldTopic, 32);
+
+    #[test]
+    fn new_topic_format_serialization() {
+        // Check that topics previously serialized using the old code can still be
+        // deserialized. The only place where this matters is Relay mailbox
+        // entry, which uses `postcard`.
+        let topic = OldDecodedTopic::generate();
+        let serialized_topic_bytes = postcard::to_stdvec(&topic).unwrap();
+        let deserialized_topic: DecodedTopic =
+            postcard::from_bytes(&serialized_topic_bytes).unwrap();
+        assert_eq!(topic.as_ref(), deserialized_topic.as_ref());
+        assert_eq!(deserialized_topic.kind(), TopicKind::Legacy);
+
+        let topic = DecodedTopic::pairing(Region::Eu);
+        let serialized_topic_bytes = postcard::to_stdvec(&topic).unwrap();
+        let deserialized_topic: DecodedTopic =
+            postcard::from_bytes(&serialized_topic_bytes).unwrap();
+        assert_eq!(topic.as_ref(), deserialized_topic.as_ref());
+        assert_eq!(deserialized_topic.kind(), TopicKind::Pairing);
+        assert_eq!(deserialized_topic.region(), Some(Region::Eu));
+
+        // No way to avoid this - 32 `0` bytes array turns out to match the new topic id
+        // format.
+        let bytes = [0u8; 32];
+        let deserialized_topic: DecodedTopic = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_topic.kind(), TopicKind::Pairing);
+        assert_eq!(deserialized_topic.region(), Some(Region::Eu));
+
+        // First 14 `0` bytes - new topic format
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1,
+        ];
+        let deserialized_topic: DecodedTopic = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_topic.kind(), TopicKind::WcpPairing);
+        assert_eq!(deserialized_topic.region(), Some(Region::Us));
+
+        // Less than 14 `0` bytes - legacy topic format
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1,
+        ];
+        let deserialized_topic: DecodedTopic = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_topic.kind(), TopicKind::Legacy);
+        assert_eq!(deserialized_topic.bytes(), &bytes);
+
+        let bytes = [
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1,
+        ];
+        let deserialized_topic: DecodedTopic = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_topic.kind(), TopicKind::Legacy);
+
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1,
+        ];
+        let deserialized_topic: DecodedTopic = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_topic.kind(), TopicKind::Legacy);
+
+        // First 14 `0` bytes, but the `TopicId` is invalid - legacy topic.
+        let bytes = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1,
+        ];
+        let deserialized_topic: DecodedTopic = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized_topic.kind(), TopicKind::Legacy);
     }
 }


### PR DESCRIPTION
# Description

Introduces a new Relay-side generated topic ID format (18 bytes) that encodes the use-case (WCP/non-WCP) and Relay region.

How Has This Been Tested?

Unit

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
