### PR TITLE
feat: ProposeSessionV2

### DIFF
--- a/relay_client/src/websocket.rs
+++ b/relay_client/src/websocket.rs
@@ -17,6 +17,7 @@ use {
             CreateTopic,
             FetchMessages,
             ProposeSession,
+            ProposeSessionV2,
             Publish,
             Receipt,
             SessionProperties,
@@ -174,6 +175,23 @@ impl Client {
     ) -> ResponseFuture<ProposeSession> {
         let (request, response) = create_request(ProposeSession {
             pairing_topic,
+            session_proposal: session_proposal.into(),
+            attestation: attestation.into(),
+            analytics: analytics.map(Into::into),
+        });
+
+        self.request(request);
+
+        response
+    }
+
+    pub fn propose_session_v2(
+        &self,
+        session_proposal: impl Into<Arc<str>>,
+        attestation: impl Into<Option<Arc<str>>>,
+        analytics: Option<AnalyticsData>,
+    ) -> ResponseFuture<ProposeSessionV2> {
+        let (request, response) = create_request(ProposeSessionV2 {
             session_proposal: session_proposal.into(),
             attestation: attestation.into(),
             analytics: analytics.map(Into::into),

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -284,6 +284,12 @@ pub struct ProposeSession<T = Topic> {
 
 pub type ProposeSessionV2 = ProposeSession<()>;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposeSessionV2Response {
+    pub pairing_topic: Topic,
+}
+
 impl ProposeSession {
     pub fn to_session_proposal(&self) -> Publish {
         Publish {
@@ -332,7 +338,7 @@ impl ServiceRequest for ProposeSession {
 
 impl ServiceRequest for ProposeSessionV2 {
     type Error = ProposeSessionError;
-    type Response = Topic;
+    type Response = ProposeSessionV2Response;
 
     fn validate(&self) -> Result<(), PayloadError> {
         if self.session_proposal.is_empty() {

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -273,14 +273,16 @@ pub enum ProposeSessionError {
 /// Propose session request parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ProposeSession {
-    pub pairing_topic: Topic,
+pub struct ProposeSession<T = Topic> {
+    pub pairing_topic: T,
     pub session_proposal: Arc<str>,
     pub attestation: Option<Arc<str>>,
 
     #[serde(default, flatten, skip_serializing_if = "is_default")]
     pub analytics: Option<AnalyticsWrapper>,
 }
+
+pub type ProposeSessionV2 = ProposeSession<()>;
 
 impl ProposeSession {
     pub fn to_session_proposal(&self) -> Publish {
@@ -292,6 +294,17 @@ impl ProposeSession {
             tag: 1100,
             ttl_secs: 300,
             analytics: self.analytics.clone(),
+        }
+    }
+}
+
+impl ProposeSessionV2 {
+    pub fn with_pairing_topic(self, topic: Topic) -> ProposeSession {
+        ProposeSession {
+            pairing_topic: topic,
+            session_proposal: self.session_proposal,
+            attestation: self.attestation,
+            analytics: self.analytics0t,
         }
     }
 }
@@ -314,6 +327,23 @@ impl ServiceRequest for ProposeSession {
 
     fn into_params(self) -> Params {
         Params::ProposeSession(self)
+    }
+}
+
+impl ServiceRequest for ProposeSessionV2 {
+    type Error = ProposeSessionError;
+    type Response = Topic;
+
+    fn validate(&self) -> Result<(), PayloadError> {
+        if self.session_proposal.is_empty() {
+            Err(PayloadError::InvalidParams)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn into_params(self) -> Params {
+        Params::ProposeSessionV2(self)
     }
 }
 
@@ -1037,6 +1067,10 @@ pub enum Params {
     #[serde(rename = "wc_proposeSession")]
     ProposeSession(ProposeSession),
 
+    /// Parameters to propose session V2.
+    #[serde(rename = "wc_proposeSessionV2")]
+    ProposeSessionV2(ProposeSessionV2),
+
     /// Parameters to approve session.
     #[serde(rename = "wc_approveSession")]
     ApproveSession(ApproveSession),
@@ -1142,6 +1176,7 @@ impl Request {
         match &self.params {
             Params::CreateTopic(params) => params.validate(),
             Params::ProposeSession(params) => params.validate(),
+            Params::ProposeSessionV2(params) => params.validate(),
             Params::ApproveSession(params) => params.validate(),
             Params::Subscribe(params) => params.validate(),
             Params::SubscribeBlocking(params) => params.validate(),

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -273,8 +273,8 @@ pub enum ProposeSessionError {
 /// Propose session request parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ProposeSession<T = Topic> {
-    pub pairing_topic: T,
+pub struct ProposeSession {
+    pub pairing_topic: Topic,
     pub session_proposal: Arc<str>,
     pub attestation: Option<Arc<str>>,
 
@@ -282,7 +282,16 @@ pub struct ProposeSession<T = Topic> {
     pub analytics: Option<AnalyticsWrapper>,
 }
 
-pub type ProposeSessionV2 = ProposeSession<()>;
+/// [`ProposeSession`] without `pairing_topic`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposeSessionV2 {
+    pub session_proposal: Arc<str>,
+    pub attestation: Option<Arc<str>>,
+
+    #[serde(default, flatten, skip_serializing_if = "is_default")]
+    pub analytics: Option<AnalyticsWrapper>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -310,7 +310,7 @@ impl ProposeSessionV2 {
             pairing_topic: topic,
             session_proposal: self.session_proposal,
             attestation: self.attestation,
-            analytics: self.analytics0t,
+            analytics: self.analytics,
         }
     }
 }

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -83,6 +83,34 @@ fn propose_session() {
 }
 
 #[test]
+fn propose_session_v2() {
+    let payload: Payload = Payload::Request(Request::new(
+        1.into(),
+        Params::ProposeSessionV2(ProposeSessionV2 {
+            session_proposal: "proposal".into(),
+            attestation: Some("attestation".into()),
+            analytics: Some(AnalyticsWrapper::new(AnalyticsData {
+                correlation_id: Some(42),
+                ..Default::default()
+            })),
+        }),
+    ));
+
+    let serialized = serde_json::to_string(&payload).unwrap();
+
+    assert_eq!(
+        &serialized,
+        r#"{"id":1,"jsonrpc":"2.0","method":"wc_proposeSessionV2","params":{"sessionProposal":"proposal","attestation":"attestation","correlationId":42}}"#
+    );
+
+    assert!(!serialized.contains("pairingTopic"));
+
+    let deserialized: Payload = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(&payload, &deserialized)
+}
+
+#[test]
 fn approve_session() {
     // Filled properties.
     let payload: Payload = Payload::Request(Request::new(


### PR DESCRIPTION
# Description

Introduces a new `wc_proposeSessionV2` method that returns pairing topic id instead of requiring it to be provided.

## How Has This Been Tested?

Relay staging

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
