### PR TITLE
Enable fully switching to rustls

### DIFF
--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [features]
 default = ["tokio-tungstenite/native-tls", "reqwest/default-tls"]
-rustls = ["tokio-tungstenite/rustls-tls-native-roots", "reqwest/rustls-tls"]
+rustls = ["tokio-tungstenite/rustls-tls-native-roots", "reqwest/rustls-tls", "reqwest/rustls-tls-native-roots"]
 
 [dependencies]
 relay_rpc = { path = "../relay_rpc" }

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [features]
-default = ["tokio-tungstenite/native-tls"]
-rustls = ["tokio-tungstenite/rustls-tls-native-roots"]
+default = ["tokio-tungstenite/native-tls", "reqwest/default-tls"]
+rustls = ["tokio-tungstenite/rustls-tls-native-roots", "reqwest/rustls-tls"]
 
 [dependencies]
 relay_rpc = { path = "../relay_rpc" }
@@ -21,7 +21,7 @@ url = "2.3"
 http = "1.0"
 
 # HTTP client dependencies.
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "system-proxy"] }
 
 # WebSocket client dependencies.
 tokio = { version = "1.47", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }


### PR DESCRIPTION
# Description

Hi! I noticed that the `rustls` feature doesn't fully disable OpenSSL, because it's included in the default features for reqwest 0.12 (https://github.com/seanmonstar/reqwest/blob/v0.12.28/Cargo.toml#L37 via `default-tls`). This change just disables reqwest's default features, then explicitly re-enables the necessary ones depending on the selected relay_client features. There's no change in behavior for anyone using relay_client's default features.

## How Has This Been Tested?

* Verified that GitHub workflow still passes
* Verified with `rustls` feature in a private project where the build environment does not include OpenSSL (also using `default-features = false` for relay_client)

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
